### PR TITLE
docs: Add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple web application to manage and split expenses within a group. This application allows you to create groups, add participants, record transactions, and calculate who owes whom.
 
+[**Live Demo**](https://carlo-colombo.github.io/cashsplitter-ai/)
+
 ## Features
 
 - **Create and manage groups:** Easily create new groups for different events or purposes.


### PR DESCRIPTION
Adds a "Live Demo" link to the README file, pointing to the deployed GitHub Pages site. This provides users with quick access to the running application.